### PR TITLE
Verifier: Include exponential backoff restarts

### DIFF
--- a/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/client/VerifierClient.kt
+++ b/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/client/VerifierClient.kt
@@ -7,7 +7,6 @@ import io.provenance.client.protobuf.extensions.getBaseAccount
 import io.provenance.client.protobuf.extensions.getTx
 import io.provenance.eventstream.decoder.moshiDecoderAdapter
 import io.provenance.eventstream.net.okHttpNetAdapter
-import io.provenance.eventstream.utils.backoff
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -45,7 +44,6 @@ import tech.figure.classification.asset.verifier.event.EventHandlerParameters
 import tech.figure.classification.asset.verifier.provenance.AssetClassificationEvent
 import tech.figure.classification.asset.verifier.util.eventstream.verifierBlockDataFlow
 import java.util.concurrent.atomic.AtomicLong
-import kotlin.time.Duration
 
 class VerifierClient(private val config: VerifierClientConfig) {
     // Cast the provided processor to T of Any to make creation and usage easier on the consumer of this library

--- a/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/client/VerifierClient.kt
+++ b/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/client/VerifierClient.kt
@@ -7,6 +7,7 @@ import io.provenance.client.protobuf.extensions.getBaseAccount
 import io.provenance.client.protobuf.extensions.getTx
 import io.provenance.eventstream.decoder.moshiDecoderAdapter
 import io.provenance.eventstream.net.okHttpNetAdapter
+import io.provenance.eventstream.utils.backoff
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -33,6 +34,7 @@ import tech.figure.classification.asset.verifier.config.VerifierEvent.StreamComp
 import tech.figure.classification.asset.verifier.config.VerifierEvent.StreamExceptionOccurred
 import tech.figure.classification.asset.verifier.config.VerifierEvent.StreamExited
 import tech.figure.classification.asset.verifier.config.VerifierEvent.StreamRestarted
+import tech.figure.classification.asset.verifier.config.VerifierEvent.StreamRestarting
 import tech.figure.classification.asset.verifier.config.VerifierEvent.VerifyAssetSendFailed
 import tech.figure.classification.asset.verifier.config.VerifierEvent.VerifyAssetSendSucceeded
 import tech.figure.classification.asset.verifier.config.VerifierEvent.VerifyAssetSendSyncSequenceNumberFailed
@@ -43,6 +45,7 @@ import tech.figure.classification.asset.verifier.event.EventHandlerParameters
 import tech.figure.classification.asset.verifier.provenance.AssetClassificationEvent
 import tech.figure.classification.asset.verifier.util.eventstream.verifierBlockDataFlow
 import java.util.concurrent.atomic.AtomicLong
+import kotlin.time.Duration
 
 class VerifierClient(private val config: VerifierClientConfig) {
     // Cast the provided processor to T of Any to make creation and usage easier on the consumer of this library
@@ -86,7 +89,7 @@ class VerifierClient(private val config: VerifierClientConfig) {
         return startVerifying(startingBlockHeight)
     }
 
-    private suspend fun verifyLoop(startingBlockHeight: Long?) {
+    private suspend fun verifyLoop(startingBlockHeight: Long?, restartCount: Long = 0) {
         val netAdapter = okHttpNetAdapter(
             node = config.eventStreamNode.toString(),
             okHttpClient = config.okHttpClientBuilder(),
@@ -122,12 +125,19 @@ class VerifierClient(private val config: VerifierClientConfig) {
         }
         when (config.streamRestartMode) {
             is StreamRestartMode.On -> {
-                if (config.streamRestartMode.restartDelayMs > 0) {
-                    delay(config.streamRestartMode.restartDelayMs)
-                }
-                StreamRestarted(latestBlock).send()
+                val restartDelayDuration = config.streamRestartMode.calcDelay(restartCount)
+                // Note that the stream is restarting before the delay occurs to ensure consumers know the state of the
+                // flow is about to begin again from the latest block recorded
+                StreamRestarting(
+                    restartHeight = latestBlock,
+                    restartCount = restartCount + 1,
+                    restartDelayMs = restartDelayDuration.inWholeMilliseconds,
+                ).send()
+                delay(restartDelayDuration)
+                // Note that the stream delay is over and the loop is about to restart
+                StreamRestarted(latestBlock, restartCount + 1).send()
                 // Recurse into a new event stream if the stream needs to restart
-                verifyLoop(latestBlock)
+                verifyLoop(latestBlock, restartCount = restartCount + 1)
             }
             is StreamRestartMode.Off -> {
                 StreamExited(latestBlock).send()

--- a/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/config/StreamRestartMode.kt
+++ b/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/config/StreamRestartMode.kt
@@ -1,13 +1,62 @@
 package tech.figure.classification.asset.verifier.config
 
+import io.provenance.eventstream.utils.backoff
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
 /**
  * Denotes whether or not the stream should be restarted when it fails internally.
  */
 sealed interface StreamRestartMode {
     /**
-     * Restart the stream after the specified delay in milliseconds.
+     * Restart the stream after the specified delay in milliseconds.  This value cannot exceed one minute's worth of
+     * milliseconds to ensure restart backoffs do not halt the stream for an excessive amount of time.  This value will
+     * be used as the base restart delay, and subsequent restarts will exponentially increase the delay value based on
+     * event-stream's backoff Duration calculation function.
+     *
+     * @param restartDelayMs The amount of ms to delay restarting the block flow after a failure occurs or the stream
+     * completes.  To restart without waiting, use the RESTART_IMMEDIATELY companion object value for this param.
+     * @param useExponentialBackoff If true, event-stream utils provides a backoff function that increases the delay
+     * exponentially (2 to the power of X, where X is the amount of times the flow has restarted) that is used for this
+     * purpose.  If this value is false, the restartDelayMs value will always be used for each restart.  If immediate
+     * restarts are requested, this value is ignored.
      */
-    class On(val restartDelayMs: Long = 5000L) : StreamRestartMode
+    class On(
+        val restartDelayMs: Double = DEFAULT_RESTART_DELAY_MS,
+        val useExponentialBackoff: Boolean = true,
+    ) : StreamRestartMode {
+        companion object {
+            const val DEFAULT_RESTART_DELAY_MS: Double = 2000.0
+            const val MIN_RESTART_DELAY_MS: Double = 1000.0
+            const val MAX_RESTART_DELAY_MS: Double = 60000.0
+            const val RESTART_IMMEDIATELY: Double = 0.0
+        }
+
+        init {
+            check (restartDelayMs == RESTART_IMMEDIATELY || restartDelayMs in MIN_RESTART_DELAY_MS..MAX_RESTART_DELAY_MS) { "Restart delay ms cannot be out of bounds: ${MIN_RESTART_DELAY_MS}ms - ${MAX_RESTART_DELAY_MS}ms" }
+        }
+
+        fun calcDelay(restartCount: Long): Duration = if (restartDelayMs != RESTART_IMMEDIATELY) {
+            if (useExponentialBackoff) {
+                // Use event-stream's nice backoff calculator to determine how many MS to wait until the next restart
+                // based on the amount of restarts that have occurred
+                backoff(
+                    attempt = restartCount,
+                    base = restartDelayMs,
+                    jitter = false,
+                )
+            } else {
+                // Without exponential backoff, just parse the delay ms into a Kotlin Duration as milliseconds
+                restartDelayMs.milliseconds
+            }
+        } else {
+            // If the delay ms value is set to immediate restarts, just set a duration of zero to make the delay invocation
+            // be skipped
+            Duration.ZERO
+        }
+
+
+    }
 
     /**
      * Never let the stream restart on its own.  Manual invocations of startVerifying() must be done to restart the

--- a/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/config/StreamRestartMode.kt
+++ b/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/config/StreamRestartMode.kt
@@ -33,7 +33,7 @@ sealed interface StreamRestartMode {
         }
 
         init {
-            check (restartDelayMs == RESTART_IMMEDIATELY || restartDelayMs in MIN_RESTART_DELAY_MS..MAX_RESTART_DELAY_MS) { "Restart delay ms cannot be out of bounds: ${MIN_RESTART_DELAY_MS}ms - ${MAX_RESTART_DELAY_MS}ms" }
+            check(restartDelayMs == RESTART_IMMEDIATELY || restartDelayMs in MIN_RESTART_DELAY_MS..MAX_RESTART_DELAY_MS) { "Restart delay ms cannot be out of bounds: ${MIN_RESTART_DELAY_MS}ms - ${MAX_RESTART_DELAY_MS}ms" }
         }
 
         fun calcDelay(restartCount: Long): Duration = if (restartDelayMs != RESTART_IMMEDIATELY) {
@@ -54,8 +54,6 @@ sealed interface StreamRestartMode {
             // be skipped
             Duration.ZERO
         }
-
-
     }
 
     /**

--- a/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/config/VerifierEvent.kt
+++ b/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/config/VerifierEvent.kt
@@ -48,13 +48,29 @@ sealed interface VerifierEvent {
 
     /**
      * After the stream completes, if the stream has been configured to restart, this function will be called.  This
+     * denotes the delay that will be used and the number of restarts that have previously occurred.  This event will
+     * occur before the restart delay occurs.
+     *
+     * @param restartHeight The block height at which the stream had reached when the restart was requested.  This will
+     * only be null if the stream restarts before a block height can ever be stored, which will only happen if the
+     * processor for blocks had never connected and found any data.
+     * @param restartCount The number of times that a restart has occurred.
+     * @param restartDelayMs The calculated backoff milliseconds that the verifier will wait before restarting the block
+     * flow.
+     */
+    data class StreamRestarting internal constructor(val restartHeight: Long?, val restartCount: Long, val restartDelayMs: Long) : VerifierEvent
+
+    /**
+     * After the stream completes, if the stream has been configured to restart, this function will be called.  This
      * function can be assumed to run immediately before a new instance of the stream starts with a new block height.
+     * This event will occur after the restart delay occurs.
      *
      * @param restartHeight The block height to which the stream had reached when the restart occurred.  This will only
      * be null if the stream restarts before a block height can ever be stored, which will only happen if the processor
      * for blocks had never connected and found any data.
+     * @param restartCount The number of times that a restart has occurred.
      */
-    data class StreamRestarted internal constructor(val restartHeight: Long?) : VerifierEvent
+    data class StreamRestarted internal constructor(val restartHeight: Long?, val restartCount: Long) : VerifierEvent
 
     /**
      * If the verifier is configured to not restart, this function will be called after the stream completes.  It
@@ -456,11 +472,27 @@ sealed interface VerifierEventType<E : VerifierEvent> {
 
     /**
      * After the stream completes, if the stream has been configured to restart, this function will be called.  This
+     * denotes the delay that will be used and the number of restarts that have previously occurred.  This event will
+     * occur before the restart delay occurs.
+     *
+     * @param restartHeight The block height at which the stream had reached when the restart was requested.  This will
+     * only be null if the stream restarts before a block height can ever be stored, which will only happen if the
+     * processor for blocks had never connected and found any data.
+     * @param restartCount The number of times that a restart has occurred.
+     * @param restartDelayMs The calculated backoff milliseconds that the verifier will wait before restarting the block
+     * flow.
+     */
+    object StreamRestarting : VerifierEventType<VerifierEvent.StreamRestarting>
+
+    /**
+     * After the stream completes, if the stream has been configured to restart, this function will be called.  This
      * function can be assumed to run immediately before a new instance of the stream starts with a new block height.
+     * This event will occur after the restart delay occurs.
      *
      * @param restartHeight The block height to which the stream had reached when the restart occurred.  This will only
      * be null if the stream restarts before a block height can ever be stored, which will only happen if the processor
      * for blocks had never connected and found any data.
+     * @param restartCount The number of times that a restart has occurred.
      */
     object StreamRestarted : VerifierEventType<VerifierEvent.StreamRestarted>
 

--- a/verifier/src/test/kotlin/tech/figure/classification/asset/verifier/config/StreamRestartModeTest.kt
+++ b/verifier/src/test/kotlin/tech/figure/classification/asset/verifier/config/StreamRestartModeTest.kt
@@ -1,0 +1,105 @@
+package tech.figure.classification.asset.verifier.config
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+class StreamRestartModeTest {
+    @Test
+    fun `test StreamRestartMode On immediate restart value is lower than min delay`() {
+        // This test ensures that changes to these constants won't cause unexpected behavior
+        assertTrue(
+            actual = StreamRestartMode.On.MIN_RESTART_DELAY_MS > StreamRestartMode.On.RESTART_IMMEDIATELY,
+            message = "Min delay [${StreamRestartMode.On.MIN_RESTART_DELAY_MS}] should be greater than immediate restart amount [${StreamRestartMode.On.RESTART_IMMEDIATELY}]",
+        )
+    }
+
+    @Test
+    fun `test StreamRestartMode On delay bounds`() {
+        // The min value should be accepted and not throw an exception
+        StreamRestartMode.On(restartDelayMs = StreamRestartMode.On.MIN_RESTART_DELAY_MS)
+        // The max value should be accepted and not throw an exception
+        StreamRestartMode.On(restartDelayMs = StreamRestartMode.On.MAX_RESTART_DELAY_MS)
+        // Immediate restarts should be accepted even though they're less than the min restart delay MS
+        StreamRestartMode.On(restartDelayMs = StreamRestartMode.On.RESTART_IMMEDIATELY)
+        assertFailsWith<IllegalStateException>("Values less than the immediate restart should not be accepted") {
+            StreamRestartMode.On(restartDelayMs = StreamRestartMode.On.RESTART_IMMEDIATELY - 0.00001)
+        }
+        assertFailsWith<IllegalStateException>("Values greater than the immediate restart should not be accepted") {
+            StreamRestartMode.On(restartDelayMs = StreamRestartMode.On.RESTART_IMMEDIATELY + 0.00001)
+        }
+        assertFailsWith<IllegalStateException>("Any value less than the min restart mode delay should be rejected") {
+            StreamRestartMode.On(restartDelayMs = StreamRestartMode.On.MIN_RESTART_DELAY_MS - 0.00001)
+        }
+        assertFailsWith<IllegalStateException>("Any value greater than the max restart mode delay should be rejected") {
+            StreamRestartMode.On(restartDelayMs = StreamRestartMode.On.MAX_RESTART_DELAY_MS + 0.00001)
+        }
+    }
+
+    @Test
+    fun `test calcDelay for immediate restarts`() {
+        val restartModeWithBackoff = StreamRestartMode.On(
+            restartDelayMs = StreamRestartMode.On.RESTART_IMMEDIATELY,
+            useExponentialBackoff = true,
+        )
+        repeat(10) { restartCount ->
+            assertEquals(
+                expected = Duration.ZERO,
+                actual = restartModeWithBackoff.calcDelay(restartCount.toLong()),
+                message = "WITH BACKOFF: Regardless of the restart count, immediate retries should never produce a delay, but it did for restart count [$restartCount]",
+            )
+        }
+        val restartModeWithoutBackoff = StreamRestartMode.On(
+            restartDelayMs = StreamRestartMode.On.RESTART_IMMEDIATELY,
+            useExponentialBackoff = false,
+        )
+        repeat(10) { restartCount ->
+            assertEquals(
+                expected = Duration.ZERO,
+                actual = restartModeWithoutBackoff.calcDelay(restartCount.toLong()),
+                message = "WITHOUT BACKOFF: Regardless of the restart count, immediate retries should never produce a delay, but it did for restart count [$restartCount]",
+            )
+        }
+    }
+
+    @Test
+    fun `test calcDelay for specified restarts with backoff`() {
+        // 1 Second restarts for easy-to-calculate test values
+        val restartMode = StreamRestartMode.On(restartDelayMs = 1000.0, useExponentialBackoff = true)
+        assertEquals(
+            expected = 1L,
+            actual = restartMode.calcDelay(0).inWholeSeconds,
+            message = "The first (0th counter value) retry should use the configured value of 1 second multiply by 2^0 == 1",
+        )
+        assertEquals(
+            expected = 2L,
+            actual = restartMode.calcDelay(1).inWholeSeconds,
+            message = "The second (1st counter value) retry should use the configured value of 1 second multiplied by 2^1 == 2",
+        )
+        assertEquals(
+            expected = 4L,
+            actual = restartMode.calcDelay(2).inWholeSeconds,
+            message = "The third (2nd counter value) retry should use the configured value of 1 second multiplied by 2^2 == 4"
+        )
+        assertEquals(
+            expected = 8L,
+            actual = restartMode.calcDelay(3).inWholeSeconds,
+            message = "The fourth (3rd counter value) retry should use the configured value of 1 second multiplied by 2^3 == 8",
+        )
+    }
+
+    @Test
+    fun `test calcDelay for specified restarts without backoff`() {
+        val restartMode = StreamRestartMode.On(restartDelayMs = 1000.0, useExponentialBackoff = false)
+        repeat(10) { restartCount ->
+            assertEquals(
+                expected = restartMode.restartDelayMs.milliseconds,
+                actual = restartMode.calcDelay(restartCount.toLong()),
+                message = "Regardless of restart count, the restartDelayMs should always be used as specified when useExponentialBackoff is disabled, but was different for restart count [$restartCount]",
+            )
+        }
+    }
+}


### PR DESCRIPTION
# Description
Due to the need to rip event stream's restart code out, the verifier is now in charge of restarts.  At present, it includes static restarts with a specified delay millisecond amount.  However, in the event of blockchain failures, an exponential backoff restart setup can be invaluable in preventing error spam and unnecessary processing.  This can often occur when the query node is having issues, or perhaps during an upgrade.  

This change introduces an improvement to the `StreamRestartMode` interface's `On` implementation that includes the ability to enable/disable exponential backoffs.  This is a breaking change for consumers of this library if they manually specify a restart delay, but it's a simple fix that requires them to change the input value from a `Long` to a `Double`.  

This also introduces a new `StreamRestarting` event that specifies the calculated delay to be used during the restart.