### PR TITLE
Verifier: Reactive restarts to block height

### DIFF
--- a/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/client/VerifierClient.kt
+++ b/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/client/VerifierClient.kt
@@ -89,7 +89,7 @@ class VerifierClient(private val config: VerifierClientConfig) {
 
     private suspend fun verifyLoop(
         startingBlockHeight: Long?,
-        retry: BlockRetry = BlockRetry(),
+        retry: BlockRetry = BlockRetry(block = startingBlockHeight),
     ) {
         val netAdapter = okHttpNetAdapter(
             node = config.eventStreamNode.toString(),


### PR DESCRIPTION
The current code keeps a continuous restart counter while the app is running, but this doesn't make sense.  The restart counter should reset every time a new block is encountered, ensuring that failures on new blocks get their own "retry loop" of halt times.  The current behavior keeps extending the restart delay as failures intermittently occur, which can be detrimental when random failures are occurring due to node timeouts.