### PR TITLE
Bugfix: Ensure the verifier client only watches the correct contract

### DIFF
--- a/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/client/VerifierClient.kt
+++ b/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/client/VerifierClient.kt
@@ -175,6 +175,10 @@ class VerifierClient(private val config: VerifierClientConfig) {
             EventIgnoredUnknownWasmEvent(event).send()
             return
         }
+        // If multiple asset classification smart contracts are instantiated and used in the same Provenance Blockchain
+        // environment, their events will all be detected by this client.  This check avoids attempting to process
+        // correctly-formatted contract events from a wholly different contract than the one registered in the configuration's
+        // ACClient instance
         config.acClient.queryContractAddress().also { contractAddress ->
             if (event.contractAddress != contractAddress) {
                 EventIgnoredContractMismatch(

--- a/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/client/VerifierClient.kt
+++ b/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/client/VerifierClient.kt
@@ -188,12 +188,6 @@ class VerifierClient(private val config: VerifierClientConfig) {
                 return
             }
         }
-        if (event.contractAddress != config.acClient.queryContractAddress()) {
-            EventIgnoredContractMismatch(
-                event = event,
-                message = "This client instance watches contract"
-            )
-        }
         // Only handle events that are relevant to the verifier
         if (event.eventType !in config.eventDelegator.getHandledEventTypes()) {
             EventIgnoredUnhandledEventType(event).send()

--- a/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/client/VerifierClient.kt
+++ b/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/client/VerifierClient.kt
@@ -25,6 +25,7 @@ import tech.figure.classification.asset.verifier.config.StreamRestartMode
 import tech.figure.classification.asset.verifier.config.VerificationProcessor
 import tech.figure.classification.asset.verifier.config.VerifierClientConfig
 import tech.figure.classification.asset.verifier.config.VerifierEvent
+import tech.figure.classification.asset.verifier.config.VerifierEvent.EventIgnoredContractMismatch
 import tech.figure.classification.asset.verifier.config.VerifierEvent.EventIgnoredUnhandledEventType
 import tech.figure.classification.asset.verifier.config.VerifierEvent.EventIgnoredUnknownWasmEvent
 import tech.figure.classification.asset.verifier.config.VerifierEvent.NewBlockHeightReceived
@@ -173,6 +174,21 @@ class VerifierClient(private val config: VerifierClientConfig) {
         if (event.eventType == null) {
             EventIgnoredUnknownWasmEvent(event).send()
             return
+        }
+        config.acClient.queryContractAddress().also { contractAddress ->
+            if (event.contractAddress != contractAddress) {
+                EventIgnoredContractMismatch(
+                    event = event,
+                    message = "This client instance watches contract address [$contractAddress], but this event originated from address [${event.contractAddress}]",
+                ).send()
+                return
+            }
+        }
+        if (event.contractAddress != config.acClient.queryContractAddress()) {
+            EventIgnoredContractMismatch(
+                event = event,
+                message = "This client instance watches contract"
+            )
         }
         // Only handle events that are relevant to the verifier
         if (event.eventType !in config.eventDelegator.getHandledEventTypes()) {

--- a/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/config/VerifierEvent.kt
+++ b/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/config/VerifierEvent.kt
@@ -106,6 +106,20 @@ sealed interface VerifierEvent {
     ) : VerifierEvent
 
     /**
+     * This event indicates that a parsed classification event on the event stream was originated from a different
+     * asset classification smart contract than the one configured to be watched by the VerifierClient.  This will be
+     * very common in an environment that includes multiple contract instances and can be safely ignored.
+     *
+     * @param event All values from the encountered event that match the event attribute structure emitted by the
+     * asset classification smart contract.
+     * @param message A message indicating the nature of the event.
+     */
+    data class EventIgnoredContractMismatch internal constructor(
+        val event: AssetClassificationEvent,
+        val message: String,
+    ) : VerifierEvent
+
+    /**
      * Only handle events that are relevant to the verifier.  The asset classification smart contract emits many more
      * events than the verifier client needs to handle, and this event is triggered when one of those events occur.
      * This can be safely ignored, but is available for debugging.
@@ -540,6 +554,17 @@ sealed interface VerifierEventType<E : VerifierEvent> {
      * @param message A message indicating the nature of the event.
      */
     object EventIgnoredUnknownWasmEvent : VerifierEventType<VerifierEvent.EventIgnoredUnknownWasmEvent>
+
+    /**
+     * This event indicates that a parsed classification event on the event stream was originated from a different
+     * asset classification smart contract than the one configured to be watched by the VerifierClient.  This will be
+     * very common in an environment that includes multiple contract instances and can be safely ignored.
+     *
+     * @param event All values from the encountered event that match the event attribute structure emitted by the
+     * asset classification smart contract.
+     * @param message A message indicating the nature of the event.
+     */
+    object EventIgnoredContractMismatch : VerifierEventType<VerifierEvent.EventIgnoredContractMismatch>
 
     /**
      * Only handle events that are relevant to the verifier.  The asset classification smart contract emits many more

--- a/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/provenance/ACContractKey.kt
+++ b/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/provenance/ACContractKey.kt
@@ -6,6 +6,7 @@ package tech.figure.classification.asset.verifier.provenance
  * @param eventName The string name used by the asset classification smart contract.
  */
 enum class ACContractKey(val eventName: String) {
+    // All wasm events emit this key, and it can be used to determine if an intercepted event matches the contract registered in the ACClient
     CONTRACT_ADDRESS("_contract_address"),
     EVENT_TYPE("asset_event_type"),
     ASSET_TYPE("asset_type"),

--- a/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/provenance/ACContractKey.kt
+++ b/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/provenance/ACContractKey.kt
@@ -6,6 +6,7 @@ package tech.figure.classification.asset.verifier.provenance
  * @param eventName The string name used by the asset classification smart contract.
  */
 enum class ACContractKey(val eventName: String) {
+    CONTRACT_ADDRESS("_contract_address"),
     EVENT_TYPE("asset_event_type"),
     ASSET_TYPE("asset_type"),
     SCOPE_ADDRESS("asset_scope_address"),

--- a/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/provenance/AssetClassificationEvent.kt
+++ b/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/provenance/AssetClassificationEvent.kt
@@ -26,6 +26,7 @@ class AssetClassificationEvent(
     val sourceEvent: TxEvent,
     private val inputValuesEncoded: Boolean,
 ) {
+    val contractAddress: String? by lazy { this.getEventStringValue(ACContractKey.CONTRACT_ADDRESS) }
     val eventType: ACContractEvent? by lazy {
         this.getEventValue(ACContractKey.EVENT_TYPE) { ACContractEvent.forContractName(it) }
     }

--- a/verifier/src/test/kotlin/tech/figure/classification/asset/verifier/event/CustomEventHandlerTest.kt
+++ b/verifier/src/test/kotlin/tech/figure/classification/asset/verifier/event/CustomEventHandlerTest.kt
@@ -38,6 +38,8 @@ class CustomEventHandlerTest {
         Security.addProvider(BouncyCastleProvider())
     }
 
+    private val contractAddress: String = "MOCK_CONTRACT_ADDR"
+
     @Test
     fun `test custom event handling`() = runTest {
         val capturedMetadata = mutableListOf<String>()
@@ -64,6 +66,7 @@ class CustomEventHandlerTest {
         client.handleEvent(
             event = MockTxEvent
                 .builder()
+                .addACAttribute(MockACAttribute.ContractAddress(contractAddress))
                 .addACAttribute(MockACAttribute.EventType(ACContractEvent.INSTANTIATE_CONTRACT))
                 .addACAttribute(MockACAttribute.VerifierAddress(config.verifierAccount.bech32Address))
                 .addACAttribute(MockACAttribute.AdditionalMetadata("expected value"))
@@ -79,6 +82,7 @@ class CustomEventHandlerTest {
     }
 
     private fun VerifierClientConfig.registerMocks() {
+        every { acClient.queryContractAddress() } returns contractAddress
         val mockPbClient = mockk<PbClient>()
         every { acClient.pbClient } returns mockPbClient
         val mockAuthClient = mockk<QueryBlockingStub>()

--- a/verifier/src/test/kotlin/tech/figure/classification/asset/verifier/testhelpers/MockACAttribute.kt
+++ b/verifier/src/test/kotlin/tech/figure/classification/asset/verifier/testhelpers/MockACAttribute.kt
@@ -10,6 +10,11 @@ sealed interface MockACAttribute {
 
     fun toAttribute(): Event = Event(key = key, value = value)
 
+    class ContractAddress(contractAddress: String) : MockACAttribute {
+        override val key: String = ACContractKey.CONTRACT_ADDRESS.eventName
+        override val value: String = contractAddress
+    }
+
     class EventType(eventType: ACContractEvent) : MockACAttribute {
         override val key: String = ACContractKey.EVENT_TYPE.eventName
         override val value: String = eventType.contractName


### PR DESCRIPTION
# Description
This bugfix ensures that the verifier client only watches events from the contract that is registered in its `ACClient` instance.  This will avoid scope not found errors when an event is validated but the lookup tries to fetch an `AssetScopeAttribute` from an entirely different contract than the origin.

## Note
This fix will prevent many of the "Intercepted onboard asset did not point to a scope with a scope attribute" errors found in verifier instances showing up lately due to the beta and the normal testnet contract existing in tandem.