### PR TITLE
v3.1.0: Support latest contract changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The following client/verifier versions should be used with the asset classificat
 
 | Client / Verifier | AC Smart Contract |
 |-------------------|-------------------|
+| v3.1.0+           | v3.1.0+           |
 | v3.0.0+           | v3.0.0+           |
 | v2.0.0 - v2.0.2   | v2.0.0 - v2.0.1   |
 | v1.1.3 - v1.3.0   | v1.0.3 - v1.0.8   |

--- a/client/src/main/kotlin/tech/figure/classification/asset/client/domain/execute/OnboardAssetExecute.kt
+++ b/client/src/main/kotlin/tech/figure/classification/asset/client/domain/execute/OnboardAssetExecute.kt
@@ -14,10 +14,10 @@ import tech.figure.classification.asset.client.domain.model.AssetIdentifier
  *
  * Sample usage:
  * ```kotlin
- * val executeForAsset = OnboardAssetExecute(AssetIdentifier.AssetUuid(UUID.randomUUID()), assetType, verifierAddress, routes)
+ * val executeForAsset = OnboardAssetExecute(AssetIdentifier.AssetUuid(UUID.randomUUID()), assetType, verifierAddress, routes, true)
  * val txResponse = acClient.onboardAsset(executeForAsset, signer, options)
  *
- * val executeForScope = OnboardAssetExecute(AssetIdentifier.ScopeAddress("scope1qzuq9fjkpn7prmv08geml38h999qnwke37"), assetType, verifierAddress, routes)
+ * val executeForScope = OnboardAssetExecute(AssetIdentifier.ScopeAddress("scope1qzuq9fjkpn7prmv08geml38h999qnwke37"), assetType, verifierAddress, routes, false)
  * val txResponse = acClient.onboardAsset(executeForScope, signer, options)
  * ```
  *
@@ -28,6 +28,15 @@ import tech.figure.classification.asset.client.domain.model.AssetIdentifier
  * type can be found by querying the contract.
  * @param accessRoutes Each verifier should be configured to locate the asset record data via these provided access
  * routes.
+ * @param addOsGatewayPermission An optional parameter that will cause the emitted events to include values that signal
+ * to any Object Store gateway instance watching the events that the selected verifier has permission to inspect the
+ * identified scope's records via fetch routes.  This will only cause a gateway to grant permissions to a scope to which
+ * the gateway itself already has read permissions.  This essentially means that a key held by a gateway instance must
+ * have been used to store the scope's records in an associated Provenance Object Store. This behavior defaults to TRUE
+ * when the contract does not detect this value (null is used).  If your asset classification instance does not use
+ * the object store gateway for anything, this value is irrelevant, because no scopes passed into the contract will be
+ * associated with a gateway, and any gateway instance encountering the values emitted by this value will outright
+ * ignore them.
  */
 @JsonNaming(SnakeCaseStrategy::class)
 @JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
@@ -37,4 +46,5 @@ data class OnboardAssetExecute<T>(
     val assetType: String,
     val verifierAddress: String,
     val accessRoutes: List<AccessRoute>? = null,
+    val addOsGatewayPermission: Boolean? = null,
 ) : ContractExecute

--- a/localtools/src/integrationTest/kotlin/tech/figure/classification/asset/ExecuteIntTest.kt
+++ b/localtools/src/integrationTest/kotlin/tech/figure/classification/asset/ExecuteIntTest.kt
@@ -49,6 +49,7 @@ class ExecuteIntTest : IntTestBase() {
                     identifier = AssetIdentifier.AssetUuid(UUID.randomUUID()),
                     assetType = "heloc",
                     verifierAddress = AppResources.verifierAccount.bech32Address,
+                    addOsGatewayPermission = true,
                 ),
                 signer = AppResources.assetOnboardingAccount.toAccountSigner(),
             )
@@ -96,6 +97,7 @@ class ExecuteIntTest : IntTestBase() {
                     assetType = assetType,
                     verifierAddress = AppResources.verifierAccount.bech32Address,
                     accessRoutes = AccessRoute("some route", "some name").wrapListAc(),
+                    addOsGatewayPermission = false,
                 ),
                 signer = AppResources.assetOnboardingAccount.toAccountSigner(),
             )
@@ -110,6 +112,7 @@ class ExecuteIntTest : IntTestBase() {
                 assetType = assetType,
                 verifierAddress = AppResources.verifierAccount.bech32Address,
                 accessRoutes = AccessRoute("some route", "some name").wrapListAc(),
+                addOsGatewayPermission = true,
             ),
             signer = AppResources.assetOnboardingAccount.toAccountSigner(),
         )

--- a/localtools/src/integrationTest/kotlin/testconfiguration/util/AppResources.kt
+++ b/localtools/src/integrationTest/kotlin/testconfiguration/util/AppResources.kt
@@ -8,7 +8,7 @@ object AppResources {
     // and libs are compatible with.  Local testing for unpublished versions of the smart contract's WASM file can be
     // done by tweaking ManagedProvenanceTestContainer's afterStartup function implementation to fetch the file from local
     // resources, if needed.
-    const val CONTRACT_VERSION = "3.0.0"
+    const val CONTRACT_VERSION = "3.1.1"
     const val ONBOARDING_CUSTOM_FEE_NAME = "Asset Classification Onboarding Fee"
 
     // This account is intended to simulate an account used for verifying assets


### PR DESCRIPTION
# Description
This PR includes the `addOsGatewayPermission` flag in the `OnboardAssetExecute` msg.  This change ensures support for this and the latest contract version (v3.1.1). 