### PR TITLE
Event Stream Provider

### DIFF
--- a/buildSrc/src/main/kotlin/publish-kotlin-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/publish-kotlin-library.gradle.kts
@@ -85,8 +85,10 @@ subprojects {
             }
         }
 
-        configure<SigningExtension> {
-            sign(publications["maven"])
+        if (System.getenv("SPRING_PROFILES_ACTIVE") != "development") {
+            configure<SigningExtension> {
+                sign(publications["maven"])
+            }
         }
     }
 }

--- a/buildSrc/src/main/kotlin/publish-kotlin-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/publish-kotlin-library.gradle.kts
@@ -85,7 +85,7 @@ subprojects {
             }
         }
 
-        if (System.getenv("SPRING_PROFILES_ACTIVE") != "development") {
+        if (!System.getenv("DISABLE_SIGNING").toBoolean()) {
             configure<SigningExtension> {
                 sign(publications["maven"])
             }

--- a/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/client/VerifierClient.kt
+++ b/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/client/VerifierClient.kt
@@ -8,7 +8,6 @@ import io.provenance.client.protobuf.extensions.getTx
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.launch
 import tech.figure.classification.asset.client.client.base.BroadcastOptions
 import tech.figure.classification.asset.client.domain.execute.VerifyAssetExecute
@@ -88,7 +87,7 @@ class VerifierClient(private val config: VerifierClientConfig) {
         val currentHeight = config.eventStreamProvider.currentHeight()
         var latestBlock = startingBlockHeight?.takeIf { start -> start > 0 && currentHeight?.let { it >= start } != false }
 
-        config.eventStreamProvider.processBlockForHeight(
+        config.eventStreamProvider.startProcessingFromHeight(
             latestBlock,
             onBlock = { block ->
                 // Record each block intercepted

--- a/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/config/EventStreamProvider.kt
+++ b/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/config/EventStreamProvider.kt
@@ -5,7 +5,7 @@ import tech.figure.classification.asset.verifier.provenance.AssetClassificationE
 
 interface EventStreamProvider {
     suspend fun currentHeight(): Long?
-    suspend fun processBlockForHeight(
+    suspend fun startProcessingFromHeight(
         height: Long? = null,
         onBlock: (suspend (block: BlockData) -> Unit),
         handleEvent: (suspend (event: AssetClassificationEvent) -> Unit),

--- a/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/config/EventStreamProvider.kt
+++ b/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/config/EventStreamProvider.kt
@@ -1,0 +1,16 @@
+package tech.figure.classification.asset.verifier.config
+
+import io.provenance.eventstream.stream.clients.BlockData
+import tech.figure.classification.asset.verifier.provenance.AssetClassificationEvent
+
+interface EventStreamProvider {
+    suspend fun currentHeight(): Long?
+    suspend fun processBlockForHeight(
+        height: Long? = null,
+        onBlock: (suspend (block: BlockData) -> Unit),
+        handleEvent: (suspend (event: AssetClassificationEvent) -> Unit),
+        onError: (suspend (throwable: Throwable) -> Unit),
+        onCompletion: (suspend (throwable: Throwable?) -> Unit),
+        onNetAdapterShutdownFailure: (suspend (throwable: Throwable) -> Unit)
+    )
+}

--- a/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/config/VerifierClientConfig.kt
+++ b/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/config/VerifierClientConfig.kt
@@ -16,6 +16,7 @@ import java.net.URI
 import java.util.concurrent.Executors
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.atomic.AtomicInteger
+import tech.figure.classification.asset.verifier.util.eventstream.DefaultEventStreamProvider
 
 /**
  * Configurations to tweak the behavior of the VerifierClient created with this class.
@@ -50,6 +51,7 @@ class VerifierClientConfig private constructor(
     val eventDelegator: AssetClassificationEventDelegator,
     val eventProcessors: Map<String, suspend (VerifierEvent) -> Unit>,
     val okHttpClientBuilder: () -> OkHttpClient,
+    val eventStreamProvider: EventStreamProvider,
 ) {
 
     companion object {
@@ -89,6 +91,9 @@ class VerifierClientConfig private constructor(
         private var eventDelegator: AssetClassificationEventDelegator? = null
         private val eventProcessors: MutableMap<String, suspend (VerifierEvent) -> Unit> = mutableMapOf()
         private var okHttpClientBuilder: (() -> OkHttpClient)? = null
+        private var eventStreamProvider: EventStreamProvider? = null
+
+        fun withEventStreamProvider(provider: EventStreamProvider) = apply { eventStreamProvider = provider }
 
         /**
          * Sets the event stream node value to listen to.  If unset, the configuration assumes the node to listen to will
@@ -160,6 +165,7 @@ class VerifierClientConfig private constructor(
             eventDelegator = eventDelegator ?: AssetClassificationEventDelegator.default(),
             eventProcessors = eventProcessors,
             okHttpClientBuilder = okHttpClientBuilder ?: { defaultOkHttpClient() },
+            eventStreamProvider = eventStreamProvider ?: DefaultEventStreamProvider(eventStreamNode ?: URI("ws://localhost:26657"), okHttpClientBuilder?.invoke() ?: defaultOkHttpClient())
         )
     }
 }

--- a/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/config/VerifierClientConfig.kt
+++ b/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/config/VerifierClientConfig.kt
@@ -12,11 +12,11 @@ import tech.figure.classification.asset.util.wallet.ProvenanceAccountDetail
 import tech.figure.classification.asset.verifier.client.VerificationMessage
 import tech.figure.classification.asset.verifier.client.VerifierClient
 import tech.figure.classification.asset.verifier.event.AssetClassificationEventDelegator
+import tech.figure.classification.asset.verifier.util.eventstream.DefaultEventStreamProvider
 import java.net.URI
 import java.util.concurrent.Executors
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.atomic.AtomicInteger
-import tech.figure.classification.asset.verifier.util.eventstream.DefaultEventStreamProvider
 
 /**
  * Configurations to tweak the behavior of the VerifierClient created with this class.

--- a/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/util/eventstream/DefaultEventStreamProvider.kt
+++ b/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/util/eventstream/DefaultEventStreamProvider.kt
@@ -14,13 +14,13 @@ import tech.figure.classification.asset.verifier.provenance.AssetClassificationE
 import java.net.URI
 
 class DefaultEventStreamProvider(
-    eventStreamNode: URI?,
-    httpClient: OkHttpClient?
+    eventStreamNode: URI = URI("ws://localhost:26657"),
+    httpClient: OkHttpClient = defaultOkHttpClient()
 ) : EventStreamProvider {
 
     private val netAdapter = okHttpNetAdapter(
-        node = eventStreamNode?.toString() ?: URI("ws://localhost:26657").toString(),
-        okHttpClient = httpClient ?: defaultOkHttpClient(),
+        node = eventStreamNode.toString(),
+        okHttpClient = httpClient,
     )
 
     private val decoderAdapter = moshiDecoderAdapter()

--- a/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/util/eventstream/DefaultEventStreamProvider.kt
+++ b/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/util/eventstream/DefaultEventStreamProvider.kt
@@ -1,6 +1,7 @@
 package tech.figure.classification.asset.verifier.util.eventstream
 
 import io.provenance.eventstream.decoder.moshiDecoderAdapter
+import io.provenance.eventstream.net.defaultOkHttpClient
 import io.provenance.eventstream.net.okHttpNetAdapter
 import io.provenance.eventstream.stream.clients.BlockData
 import kotlinx.coroutines.flow.catch
@@ -12,11 +13,14 @@ import tech.figure.classification.asset.verifier.config.EventStreamProvider
 import tech.figure.classification.asset.verifier.provenance.AssetClassificationEvent
 import java.net.URI
 
-class DefaultEventStreamProvider(eventStreamNode: URI, httpBuilder: OkHttpClient) : EventStreamProvider {
+class DefaultEventStreamProvider(
+    eventStreamNode: URI?,
+    httpClient: OkHttpClient?
+) : EventStreamProvider {
 
     private val netAdapter = okHttpNetAdapter(
-        node = eventStreamNode.toString(),
-        okHttpClient = httpBuilder,
+        node = eventStreamNode?.toString() ?: URI("ws://localhost:26657").toString(),
+        okHttpClient = httpClient ?: defaultOkHttpClient(),
     )
 
     private val decoderAdapter = moshiDecoderAdapter()
@@ -24,7 +28,7 @@ class DefaultEventStreamProvider(eventStreamNode: URI, httpBuilder: OkHttpClient
     override suspend fun currentHeight(): Long? =
         netAdapter.rpcAdapter.getCurrentHeight()
 
-    override suspend fun processBlockForHeight(
+    override suspend fun startProcessingFromHeight(
         height: Long?,
         onBlock: suspend (block: BlockData) -> Unit,
         handleEvent: suspend (event: AssetClassificationEvent) -> Unit,

--- a/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/util/eventstream/DefaultEventStreamProvider.kt
+++ b/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/util/eventstream/DefaultEventStreamProvider.kt
@@ -3,7 +3,6 @@ package tech.figure.classification.asset.verifier.util.eventstream
 import io.provenance.eventstream.decoder.moshiDecoderAdapter
 import io.provenance.eventstream.net.okHttpNetAdapter
 import io.provenance.eventstream.stream.clients.BlockData
-import java.net.URI
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
@@ -11,6 +10,7 @@ import kotlinx.coroutines.flow.onEach
 import okhttp3.OkHttpClient
 import tech.figure.classification.asset.verifier.config.EventStreamProvider
 import tech.figure.classification.asset.verifier.provenance.AssetClassificationEvent
+import java.net.URI
 
 class DefaultEventStreamProvider(eventStreamNode: URI, httpBuilder: OkHttpClient) : EventStreamProvider {
 

--- a/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/util/eventstream/DefaultEventStreamProvider.kt
+++ b/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/util/eventstream/DefaultEventStreamProvider.kt
@@ -1,0 +1,60 @@
+package tech.figure.classification.asset.verifier.util.eventstream
+
+import io.provenance.eventstream.decoder.moshiDecoderAdapter
+import io.provenance.eventstream.net.okHttpNetAdapter
+import io.provenance.eventstream.stream.clients.BlockData
+import java.net.URI
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
+import okhttp3.OkHttpClient
+import tech.figure.classification.asset.verifier.config.EventStreamProvider
+import tech.figure.classification.asset.verifier.provenance.AssetClassificationEvent
+
+class DefaultEventStreamProvider(eventStreamNode: URI, httpBuilder: OkHttpClient) : EventStreamProvider {
+
+    private val netAdapter = okHttpNetAdapter(
+        node = eventStreamNode.toString(),
+        okHttpClient = httpBuilder,
+    )
+
+    private val decoderAdapter = moshiDecoderAdapter()
+
+    override suspend fun currentHeight(): Long? =
+        netAdapter.rpcAdapter.getCurrentHeight()
+
+    override suspend fun processBlockForHeight(
+        height: Long?,
+        onBlock: suspend (block: BlockData) -> Unit,
+        handleEvent: suspend (event: AssetClassificationEvent) -> Unit,
+        onError: suspend (throwable: Throwable) -> Unit,
+        onCompletion: suspend (throwable: Throwable?) -> Unit,
+        onNetAdapterShutdownFailure: suspend (throwable: Throwable) -> Unit
+    ) {
+        verifierBlockDataFlow(netAdapter, decoderAdapter, from = height)
+            .catch { e -> onError(e) }
+            .onCompletion { t -> onCompletion(t) }
+            .onEach { block ->
+                onBlock(block)
+            }
+            // Map all captured block data to AssetClassificationEvents, which will remove all non-wasm events
+            // encountered
+            .map(AssetClassificationEvent::fromBlockData)
+            .collect { events ->
+                events.forEach { event -> handleEvent(event) }
+            }
+        // The event stream flow should execute infinitely unless some error occurs, so this line will only be reached
+        // on connection failures or other problems.
+        try {
+            // Attempt to shut down the net adapter before restarting or exiting the stream
+            netAdapter.shutdown()
+        } catch (e: Exception) {
+            // Emit the exception encountered on net adapter shutdown and exit the stream entirely
+            onNetAdapterShutdownFailure(e)
+            // Escape the loop entirely if the adapter fails to shut down - there should never be two adapters running
+            // in tandem via this client
+            return
+        }
+    }
+}


### PR DESCRIPTION
## Overview

To circumvent event stream issues, now allowing multiple ways to get / process blocks from the event stream. 

## Changes 

- Allowing an optional implementation of `EventStreamProvider` within the `ClientConfig` that is used for getting current block height / processing block events 
- The default implementation uses the provenance event stream net adapter, while allowing custom providers to be set in the config. 

This should have minimal impact on consumers.

Note: i've tested these changes locally against `asset-classification-verifier` with the `classification_demonstration` gradle task 