### PR TITLE
Wrapping current height in retry block

### DIFF
--- a/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/util/eventstream/providers/BlockApiEventStreamProvider.kt
+++ b/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/util/eventstream/providers/BlockApiEventStreamProvider.kt
@@ -53,7 +53,12 @@ class BlockApiEventStreamProvider(
                 // Once we've met the current block, no need to keep spinning. Wait here for 4 seconds and process again.
                 delay(DEFAULT_BLOCK_DELAY_MS.milliseconds)
                 from = lastProcessed.incrementAndGet()
-                current = currentHeight()
+
+                retry?.tryAction {
+                    current = currentHeight()
+                } ?: run {
+                    current = currentHeight()
+                }
             }
         } catch (ex: Exception) {
             onError(ex)


### PR DESCRIPTION
## Issue

After running over the weekend, I found the block api implementation might hit a `streamExited` exception without restart (irrecoverable). This was caused by a grpc error:

```
io.grpc.StatusException: UNAVAILABLE: HTTP Balancer service in fail-fast
```

## Fixes

I believe the above error was due to the current height call against the block api client. Since a failure in getting current height would be irrecoverable, the only fixes here are to wrap the currentHeight method in the retry `tryAction` block. This will allow attempting to get the current height several times before the stream exits. 