### PR TITLE
fix: use txResponse events instead of rawLog for parsing AssetClassificationEvents

### DIFF
--- a/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/client/VerifierClient.kt
+++ b/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/client/VerifierClient.kt
@@ -13,7 +13,6 @@ import tech.figure.classification.asset.client.client.base.BroadcastOptions
 import tech.figure.classification.asset.client.domain.execute.VerifyAssetExecute
 import tech.figure.classification.asset.client.domain.model.AssetIdentifier
 import tech.figure.classification.asset.util.extensions.alsoIfAc
-import tech.figure.classification.asset.util.extensions.toProvenanceTxEventsAc
 import tech.figure.classification.asset.util.wallet.AccountSigner
 import tech.figure.classification.asset.verifier.config.RecoveryStatus
 import tech.figure.classification.asset.verifier.config.StreamRestartMode
@@ -57,7 +56,7 @@ class VerifierClient(private val config: VerifierClientConfig) {
         val tx = config.acClient.pbClient.cosmosService.getTx(txHash)
         val events = AssetClassificationEvent.fromVerifierTxEvents(
             sourceTx = tx,
-            txEvents = tx.txResponse.toProvenanceTxEventsAc()
+            txEvents = tx.txResponse.eventsList
         )
         config.coroutineScope.launch {
             events.forEach { acEvent -> handleEvent(acEvent) }

--- a/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/provenance/AssetClassificationEvent.kt
+++ b/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/provenance/AssetClassificationEvent.kt
@@ -2,10 +2,10 @@ package tech.figure.classification.asset.verifier.provenance
 
 import cosmos.tx.v1beta1.ServiceOuterClass.GetTxResponse
 import tech.figure.classification.asset.client.domain.model.AssetOnboardingStatus
-import tech.figure.classification.asset.util.models.ProvenanceTxEvents
 import tech.figure.eventstream.decodeBase64
 import tech.figure.eventstream.stream.models.Event
 import tech.figure.eventstream.stream.models.TxEvent
+import tendermint.abci.Types
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 
@@ -42,9 +42,9 @@ class AssetClassificationEvent(
 
         fun fromVerifierTxEvents(
             sourceTx: GetTxResponse,
-            txEvents: List<ProvenanceTxEvents>
+            txEvents: List<Types.Event>
         ): List<AssetClassificationEvent> =
-            txEvents.flatMap { it.events }
+            txEvents
                 .filter { it.type == WASM_EVENT_TYPE }
                 .map { event ->
                     AssetClassificationEvent(
@@ -57,17 +57,17 @@ class AssetClassificationEvent(
                             },
                             txHash = sourceTx.txResponse.txhash,
                             eventType = event.type,
-                            attributes = event.attributes.map { attribute ->
+                            attributes = event.attributesList.map { attribute ->
                                 Event(
-                                    key = attribute.key,
-                                    value = attribute.value
+                                    key = attribute.key.toStringUtf8(),
+                                    value = attribute.value.toStringUtf8()
                                 )
                             },
                             fee = sourceTx.tx.authInfo.fee.amountList.firstOrNull()?.amount?.toBigIntegerOrNull(),
                             denom = sourceTx.tx.authInfo.fee.amountList.firstOrNull()?.denom,
                             note = null
                         ),
-                        inputValuesEncoded = false
+                        inputValuesEncoded = true
                     )
                 }
     }

--- a/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/provenance/AssetClassificationEvent.kt
+++ b/verifier/src/main/kotlin/tech/figure/classification/asset/verifier/provenance/AssetClassificationEvent.kt
@@ -67,7 +67,7 @@ class AssetClassificationEvent(
                             denom = sourceTx.tx.authInfo.fee.amountList.firstOrNull()?.denom,
                             note = null
                         ),
-                        inputValuesEncoded = true
+                        inputValuesEncoded = false
                     )
                 }
     }

--- a/verifier/src/test/kotlin/tech/figure/classification/asset/verifier/provenance/AssetClassificationEventTest.kt
+++ b/verifier/src/test/kotlin/tech/figure/classification/asset/verifier/provenance/AssetClassificationEventTest.kt
@@ -14,14 +14,14 @@ class AssetClassificationEventTest {
                 addEventsBuilder().apply {
                     type = WASM_EVENT_TYPE
                     addAttributesBuilder().apply {
-                        key = "X2NvbnRyYWN0X2FkZHJlc3M=".toByteString()
-                        value = "cGIxbWZ1aDQ5bjIyOW5xbWczeW1tZmg3NGRhcngwNGdqeXZtdzh1OWMK".toByteString()
+                        key = "_contract_address".toByteString()
+                        value = "testaddress".toByteString()
                         index = false
                     }
                     // "asset_event_type" : "onboard_asset"
                     addAttributesBuilder().apply {
-                        key = "YXNzZXRfZXZlbnRfdHlwZQ==".toByteString()
-                        value = "b25ib2FyZF9hc3NldA==".toByteString()
+                        key = "asset_event_type".toByteString()
+                        value = "onboard_asset".toByteString()
                         index = false
                     }
                 }
@@ -29,8 +29,8 @@ class AssetClassificationEventTest {
                 addEventsBuilder().apply {
                     type = "execute"
                     addAttributesBuilder().apply {
-                        key = "X2NvbnRyYWN0X2FkZHJlc3M=".toByteString()
-                        value = "cGIxbWZ1aDQ5bjIyOW5xbWczeW1tZmg3NGRhcngwNGdqeXZtdzh1OWMK".toByteString()
+                        key = "_contract_address".toByteString()
+                        value = "testaddress".toByteString()
                     }
                 }
             }

--- a/verifier/src/test/kotlin/tech/figure/classification/asset/verifier/provenance/AssetClassificationEventTest.kt
+++ b/verifier/src/test/kotlin/tech/figure/classification/asset/verifier/provenance/AssetClassificationEventTest.kt
@@ -1,0 +1,49 @@
+package tech.figure.classification.asset.verifier.provenance
+
+import cosmos.tx.v1beta1.ServiceOuterClass
+import io.provenance.scope.util.toByteString
+import tech.figure.classification.asset.verifier.provenance.AssetClassificationEvent.Companion.fromVerifierTxEvents
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AssetClassificationEventTest {
+    @Test
+    fun `fromVerifierTxEvents filters and maps wasm events to AssetClassificationEvent`() {
+        val tx = ServiceOuterClass.GetTxResponse.newBuilder().apply {
+            txResponseBuilder.apply {
+                addEventsBuilder().apply {
+                    type = WASM_EVENT_TYPE
+                    addAttributesBuilder().apply {
+                        key = "X2NvbnRyYWN0X2FkZHJlc3M=".toByteString()
+                        value = "cGIxbWZ1aDQ5bjIyOW5xbWczeW1tZmg3NGRhcngwNGdqeXZtdzh1OWMK".toByteString()
+                        index = false
+                    }
+                    // "asset_event_type" : "onboard_asset"
+                    addAttributesBuilder().apply {
+                        key = "YXNzZXRfZXZlbnRfdHlwZQ==".toByteString()
+                        value = "b25ib2FyZF9hc3NldA==".toByteString()
+                        index = false
+                    }
+                }
+
+                addEventsBuilder().apply {
+                    type = "execute"
+                    addAttributesBuilder().apply {
+                        key = "X2NvbnRyYWN0X2FkZHJlc3M=".toByteString()
+                        value = "cGIxbWZ1aDQ5bjIyOW5xbWczeW1tZmg3NGRhcngwNGdqeXZtdzh1OWMK".toByteString()
+                    }
+                }
+            }
+        }.build()
+
+        val events = fromVerifierTxEvents(
+            sourceTx = tx,
+            txEvents = tx.txResponse.eventsList
+        )
+
+        assertEquals(events.size, 1)
+        events[0].run {
+            assertEquals(eventType, ACContractEvent.ONBOARD_ASSET)
+        }
+    }
+}


### PR DESCRIPTION
## Context

Failed calling `manualVerifyHash` against a txn in provenance 1.9.0 due to `rawLog` being an empty string (possibly deprecated) when parsing for AssetClassificationEvents

```
com.fasterxml.jackson.databind.exc.MismatchedInputException: No content to map due to end-of-input
 at [Source: (String)""; line: 1, column: 0]
```

## Changes

Use the events from the cosmos proto for mapping to AssetClassificationEvents